### PR TITLE
Add force flag to library symbolic link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -156,7 +156,7 @@ if [ ${INSTALL_DASHBOARD} -eq 1 ]; then
     libs=( wx )
     for lib in ${libs[@]}
     do
-        ln -s $lib_system_path/$lib $lib_virtualenv_path/$lib
+        ln -sf $lib_system_path/$lib $lib_virtualenv_path/$lib
     done
 fi
 


### PR DESCRIPTION
Link step fails if continuing installation after interruption, requiring manual deletion of the link. Adding a force flag overrides the existing symbolic link from attempted installation in the newly created virtual environment.