### PR TITLE
Measurements as observation

### DIFF
--- a/agents/actor_critic_agent.py
+++ b/agents/actor_critic_agent.py
@@ -20,17 +20,6 @@ from utils import *
 import scipy.signal
 
 
-def last_sample(state):
-    """
-    given a batch of states, return the last sample of the batch with length 1
-    batch axis.
-    """
-    return {
-        k: np.expand_dims(v[-1], 0)
-        for k, v in state.items()
-    }
-
-
 # Actor Critic - https://arxiv.org/abs/1602.01783
 class ActorCriticAgent(PolicyOptimizationAgent):
     def __init__(self, env, tuning_parameters, replicated_device=None, thread_id=0, create_target_network = False):

--- a/agents/actor_critic_agent.py
+++ b/agents/actor_critic_agent.py
@@ -101,9 +101,7 @@ class ActorCriticAgent(PolicyOptimizationAgent):
             actions = np.expand_dims(actions, -1)
 
         # train
-        inputs = copy.copy(current_states)
-        inputs['output_1_0'] = actions
-        result = self.main_network.online_network.accumulate_gradients(inputs,
+        result = self.main_network.online_network.accumulate_gradients({**current_states, 'output_1_0': actions},
                                                                        [state_value_head_targets, action_advantages])
 
         # logging

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -378,9 +378,10 @@ class Agent(object):
             state['observation'] = stack_observation([], state['observation'], self.tp.env.observation_stack_size)
 
             self.curr_state = state
-            # TODO: this should be handled in the environment
             if self.tp.agent.use_measurements:
+                # TODO: this should be handled in the environment
                 self.curr_state['measurements'] = self.env.measurements
+
                 if self.tp.agent.use_accumulated_reward_as_measurement:
                     self.curr_state['measurements'] = np.append(self.curr_state['measurements'], 0)
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -338,6 +338,17 @@ class Agent(object):
             reward = max(reward, self.tp.env.reward_clipping_min)
         return reward
 
+    def tf_input_state(self, curr_state):
+        """
+        convert curr_state into input tensors tensorflow is expecting.
+        """
+        # add batch axis with length 1 onto each value
+        # extract values from the state based on agent.input_types
+        input_state = {}
+        for input_name in self.tp.agent.input_types.keys():
+            input_state[input_name] = np.expand_dims(np.array(curr_state[input_name]), 0)
+        return input_state
+
     def act(self, phase=RunPhase.TRAIN):
         """
         Take one step in the environment according to the network prediction and store the transition in memory

--- a/agents/bc_agent.py
+++ b/agents/bc_agent.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-from agents.imitation_agent import *
+import numpy as np
+
+from agents.imitation_agent import ImitationAgent
 
 
 # Behavioral Cloning Agent
@@ -25,16 +27,13 @@ class BCAgent(ImitationAgent):
     def learn_from_batch(self, batch):
         current_states, _, actions, _, _, _ = self.extract_batch(batch)
 
-        # create the inputs for the network
-        input = current_states
-
         # the targets for the network are the actions since this is supervised learning
         if self.env.discrete_controls:
             targets = np.eye(self.env.action_space_size)[[actions]]
         else:
             targets = actions
 
-        result = self.main_network.train_and_sync_networks(input, targets)
+        result = self.main_network.train_and_sync_networks(current_states, targets)
         total_loss = result[0]
 
         return total_loss

--- a/agents/clipped_ppo_agent.py
+++ b/agents/clipped_ppo_agent.py
@@ -114,7 +114,6 @@ class ClippedPPOAgent(ActorCriticAgent):
                 # otherwise, it has both a mean and standard deviation
                 for input_index, input in enumerate(old_policy_distribution):
                     inputs['output_0_{}'.format(input_index + 1)] = input
-                # print('old_policy_distribution.shape', len(old_policy_distribution))
                 total_loss, policy_losses, unclipped_grads, fetch_result =\
                     self.main_network.online_network.accumulate_gradients(
                         inputs, [total_return, advantages], additional_fetches=fetches)

--- a/agents/ddpg_agent.py
+++ b/agents/ddpg_agent.py
@@ -54,7 +54,7 @@ class DDPGAgent(ActorCriticAgent):
         actions_mean = self.actor_network.online_network.predict(current_states)
         critic_online_network = self.critic_network.online_network
         # TODO: convert into call to predict, current method ignores lstm middleware for example
-        action_gradients = self.critic_network.sess.run(critic_online_network.gradients_wrt_inputs[1],
+        action_gradients = self.critic_network.sess.run(critic_online_network.gradients_wrt_inputs['action'],
                                                         feed_dict=critic_online_network._feed_dict({
                                                             **current_states,
                                                             'action': actions_mean,

--- a/agents/dfp_agent.py
+++ b/agents/dfp_agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Intel Corporation 
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/agents/imitation_agent.py
+++ b/agents/imitation_agent.py
@@ -31,12 +31,7 @@ class ImitationAgent(Agent):
 
     def choose_action(self, curr_state, phase=RunPhase.TRAIN):
         # convert to batch so we can run it through the network
-        observation = np.expand_dims(np.array(curr_state['observation']), 0)
-        if self.tp.agent.use_measurements:
-            measurements = np.expand_dims(np.array(curr_state['measurements']), 0)
-            prediction = self.main_network.online_network.predict([observation, measurements])
-        else:
-            prediction = self.main_network.online_network.predict(observation)
+        prediction = self.main_network.online_network.predict(self.tf_input_state(curr_state))
 
         # get action values and extract the best action from it
         action_values = self.extract_action_values(prediction)

--- a/agents/n_step_q_agent.py
+++ b/agents/n_step_q_agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Intel Corporation 
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-from agents.value_optimization_agent import *
-from agents.policy_optimization_agent import *
-from logger import *
-from utils import *
+import numpy as np
 import scipy.signal
+
+from agents.value_optimization_agent import ValueOptimizationAgent
+from agents.policy_optimization_agent import PolicyOptimizationAgent
+from logger import logger
+from utils import Signal, last_sample
 
 
 # N Step Q Learning Agent - https://arxiv.org/abs/1602.01783
@@ -56,7 +57,7 @@ class NStepQAgent(ValueOptimizationAgent, PolicyOptimizationAgent):
             if game_overs[-1]:
                 R = 0
             else:
-                R = np.max(self.main_network.target_network.predict(np.expand_dims(next_states[-1], 0)))
+                R = np.max(self.main_network.target_network.predict(last_sample(next_states)))
 
             for i in reversed(range(num_transitions)):
                 R = rewards[i] + self.tp.agent.discount * R
@@ -66,7 +67,7 @@ class NStepQAgent(ValueOptimizationAgent, PolicyOptimizationAgent):
             assert True, 'The available values for targets_horizon are: 1-Step, N-Step'
 
         # train
-        result = self.main_network.online_network.accumulate_gradients([current_states], [state_value_head_targets])
+        result = self.main_network.online_network.accumulate_gradients(current_states, [state_value_head_targets])
 
         # logging
         total_loss, losses, unclipped_grads = result[:3]

--- a/agents/naf_agent.py
+++ b/agents/naf_agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Intel Corporation 
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,10 @@
 # limitations under the License.
 #
 
-from agents.value_optimization_agent import *
+import numpy as np
+
+from agents.value_optimization_agent import ValueOptimizationAgent
+from utils import RunPhase, Signal
 
 
 # Normalized Advantage Functions - https://arxiv.org/pdf/1603.00748.pdf
@@ -31,14 +34,17 @@ class NAFAgent(ValueOptimizationAgent):
         current_states, next_states, actions, rewards, game_overs, _ = self.extract_batch(batch)
 
         # TD error = r + discount*v_st_plus_1 - q_st
-        v_st_plus_1 = self.main_network.sess.run(self.main_network.target_network.output_heads[0].V,
-                                                 feed_dict={self.main_network.target_network.inputs[0]: next_states})
+        v_st_plus_1 = self.main_network.target_network.predict(
+            next_states,
+            self.main_network.target_network.output_heads[0].V,
+            squeeze_output=False,
+        )
         TD_targets = np.expand_dims(rewards, -1) + (1.0 - np.expand_dims(game_overs, -1)) * self.tp.agent.discount * v_st_plus_1
 
         if len(actions.shape) == 1:
             actions = np.expand_dims(actions, -1)
 
-        result = self.main_network.train_and_sync_networks([current_states, actions], TD_targets)
+        result = self.main_network.train_and_sync_networks({**current_states, 'output_0_0': actions}, TD_targets)
         total_loss = result[0]
 
         return total_loss
@@ -47,21 +53,21 @@ class NAFAgent(ValueOptimizationAgent):
         assert not self.env.discrete_controls, 'NAF works only for continuous control problems'
 
         # convert to batch so we can run it through the network
-        observation = np.expand_dims(np.array(curr_state['observation']), 0)
+        # observation = np.expand_dims(np.array(curr_state['observation']), 0)
         naf_head = self.main_network.online_network.output_heads[0]
-        action_values = self.main_network.sess.run(naf_head.mu,
-                                            feed_dict={self.main_network.online_network.inputs[0]: observation})
+        action_values = self.main_network.online_network.predict(
+            self.tf_input_state(curr_state),
+            outputs=naf_head.mu,
+            squeeze_output=False,
+        )
         if phase == RunPhase.TRAIN:
             action = self.exploration_policy.get_action(action_values)
         else:
             action = action_values
 
-        Q, L, A, mu, V = self.main_network.sess.run(
-            [naf_head.Q, naf_head.L, naf_head.A, naf_head.mu, naf_head.V],
-            feed_dict={
-                self.main_network.online_network.inputs[0]: observation,
-                self.main_network.online_network.inputs[1]: action_values
-            }
+        Q, L, A, mu, V = self.main_network.online_network.predict(
+            {**self.tf_input_state(curr_state), 'output_0_0': action_values},
+            outputs=[naf_head.Q, naf_head.L, naf_head.A, naf_head.mu, naf_head.V],
         )
 
         # store the q values statistics for logging

--- a/agents/nec_agent.py
+++ b/agents/nec_agent.py
@@ -18,6 +18,7 @@ import numpy as np
 
 from agents.value_optimization_agent import ValueOptimizationAgent
 from logger import screen
+from utils import RunPhase
 
 
 # Neural Episodic Control - https://arxiv.org/pdf/1703.01988.pdf
@@ -40,7 +41,7 @@ class NECAgent(ValueOptimizationAgent):
                 screen.log_title("Finished collecting initial entries in DND. Starting to train network...")
 
         current_states, next_states, actions, rewards, game_overs, total_return = self.extract_batch(batch)
-        result = self.main_network.train_and_sync_networks([current_states, actions], total_return)
+        result = self.main_network.train_and_sync_networks(current_states, total_return)
         total_loss = result[0]
 
         return total_loss

--- a/agents/nec_agent.py
+++ b/agents/nec_agent.py
@@ -16,7 +16,8 @@
 
 import numpy as np
 
-from agents.value_optimization_agent import *
+from agents.value_optimization_agent import ValueOptimizationAgent
+from logger import screen
 
 
 # Neural Episodic Control - https://arxiv.org/pdf/1703.01988.pdf

--- a/agents/ppo_agent.py
+++ b/agents/ppo_agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Intel Corporation 
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ class PPOAgent(ActorCriticAgent):
         # * Found not to have any impact *
         # current_states_with_timestep = self.concat_state_and_timestep(batch)
 
-        current_state_values = self.critic_network.online_network.predict([current_states]).squeeze()
+        current_state_values = self.critic_network.online_network.predict(current_state).squeeze()
 
         # calculate advantages
         advantages = []
@@ -105,11 +105,11 @@ class PPOAgent(ActorCriticAgent):
                 current_states_batch = current_states[i * batch_size:(i + 1) * batch_size]
                 total_return_batch = total_return[i * batch_size:(i + 1) * batch_size]
                 old_policy_values = force_list(self.critic_network.target_network.predict(
-                    [current_states_batch]).squeeze())
+                    current_states_batch).squeeze())
                 if self.critic_network.online_network.optimizer_type != 'LBFGS':
                     targets = total_return_batch
                 else:
-                    current_values = self.critic_network.online_network.predict([current_states_batch])
+                    current_values = self.critic_network.online_network.predict(current_states_batch)
                     targets = current_values * (1 - mix_fraction) + total_return_batch * mix_fraction
 
                 value_loss = self.critic_network.online_network.\

--- a/agents/ppo_agent.py
+++ b/agents/ppo_agent.py
@@ -112,8 +112,12 @@ class PPOAgent(ActorCriticAgent):
                     current_values = self.critic_network.online_network.predict(current_states_batch)
                     targets = current_values * (1 - mix_fraction) + total_return_batch * mix_fraction
 
+                inputs = copy.copy(current_states_batch)
+                for input_index, input in enumerate(old_policy_values):
+                    inputs['output_0_{}'.format(input_index)] = input
+
                 value_loss = self.critic_network.online_network.\
-                    accumulate_gradients([current_states_batch] + old_policy_values, targets)
+                    accumulate_gradients(inputs, targets)
                 self.critic_network.apply_gradients_to_online_network()
                 if self.tp.distributed:
                     self.critic_network.apply_gradients_to_global_network()

--- a/agents/qr_dqn_agent.py
+++ b/agents/qr_dqn_agent.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Intel Corporation 
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,8 +56,11 @@ class QuantileRegressionDQNAgent(ValueOptimizationAgent):
             quantile_midpoints[idx, :] = quantile_midpoints[idx, sorted_quantiles[idx]]
 
         # train
-        result = self.main_network.train_and_sync_networks([current_states, actions_locations, quantile_midpoints], TD_targets)
+        result = self.main_network.train_and_sync_networks({
+            **current_states,
+            'output_0_0': actions_locations,
+            'output_0_1': quantile_midpoints,
+        }, TD_targets)
         total_loss = result[0]
 
         return total_loss
-

--- a/agents/value_optimization_agent.py
+++ b/agents/value_optimization_agent.py
@@ -36,23 +36,6 @@ class ValueOptimizationAgent(Agent):
     def get_q_values(self, prediction):
         return prediction
 
-    def tf_input_state(self, curr_state):
-        """
-        convert curr_state into input tensors tensorflow is expecting.
-
-        TODO: move this function into Agent and use in as many agent implementations as possible
-        currently, other agents will likely not work with environment measurements.
-        This will become even more important as we support more complex and varied environment states.
-        """
-        # convert to batch so we can run it through the network
-        observation = np.expand_dims(np.array(curr_state['observation']), 0)
-        if self.tp.agent.use_measurements:
-            measurements = np.expand_dims(np.array(curr_state['measurements']), 0)
-            tf_input_state = [observation, measurements]
-        else:
-            tf_input_state = observation
-        return tf_input_state
-
     def get_prediction(self, curr_state):
         return self.main_network.online_network.predict(self.tf_input_state(curr_state))
 

--- a/architectures/tensorflow_components/architecture.py
+++ b/architectures/tensorflow_components/architecture.py
@@ -107,8 +107,7 @@ class TensorFlowArchitecture(Architecture):
             # gradients of the outputs w.r.t. the inputs
             # at the moment, this is only used by ddpg
             if len(self.outputs) == 1:
-                # TODO: convert gradients_with_respect_to_inputs into dictionary?
-                self.gradients_wrt_inputs = [tf.gradients(self.outputs[0], input_ph) for input_ph in self.inputs.values()]
+                self.gradients_wrt_inputs = {name: tf.gradients(self.outputs[0], input_ph) for name, input_ph in self.inputs.items()}
                 self.gradients_weights_ph = tf.placeholder('float32', self.outputs[0].shape, 'output_gradient_weights')
                 self.weighted_gradients = tf.gradients(self.outputs[0], self.trainable_weights, self.gradients_weights_ph)
 

--- a/architectures/tensorflow_components/architecture.py
+++ b/architectures/tensorflow_components/architecture.py
@@ -266,10 +266,20 @@ class TensorFlowArchitecture(Architecture):
                     time.sleep(0.00001)
 
     def _feed_dict(self, inputs):
-        return {
-            self.inputs[input_name]: input_value
-            for input_name, input_value in inputs.items()
-        }
+        feed_dict = {}
+        for input_name, input_value in inputs.items():
+            if input_name not in self.inputs:
+                raise ValueError((
+                    'input name {input_name} was provided to create a feed '
+                    'dictionary, but there is no placeholder with that name. '
+                    'placeholder names available include: {placeholder_names}'
+                ).format(
+                    input_name=input_name,
+                    placeholder_names=', '.join(self.inputs.keys())
+                ))
+
+            feed_dict[self.inputs[input_name]] = input_value
+        return feed_dict
 
     def predict(self, inputs, outputs=None):
         """

--- a/architectures/tensorflow_components/architecture.py
+++ b/architectures/tensorflow_components/architecture.py
@@ -320,22 +320,6 @@ class TensorFlowArchitecture(Architecture):
 
         return output
 
-    # def train_on_batch(self, inputs, targets, scaler=1., additional_fetches=None):
-    #     """
-    #     Given a batch of examples and targets, runs a forward pass & backward pass and then applies the gradients
-    #     :param additional_fetches: Optional tensors to fetch during the training process
-    #     :param inputs: The input for the network
-    #     :param targets: The targets corresponding to the input batch
-    #     :param scaler: A scaling factor that allows rescaling the gradients before applying them
-    #     :return: The loss of the network
-    #     """
-    #     if additional_fetches is None:
-    #         additional_fetches = []
-    #     force_list(additional_fetches)
-    #     loss = self.accumulate_gradients(inputs, targets, additional_fetches=additional_fetches)
-    #     self.apply_and_reset_gradients(self.accumulated_gradients, scaler)
-    #     return loss
-
     def get_weights(self):
         """
         :return: a list of tensors containing the network weights for each layer

--- a/architectures/tensorflow_components/architecture.py
+++ b/architectures/tensorflow_components/architecture.py
@@ -295,16 +295,16 @@ class TensorFlowArchitecture(Architecture):
 
         return feed_dict
 
-    def predict(self, inputs, outputs=None):
+    def predict(self, inputs, outputs=None, squeeze_output=True):
         """
         Run a forward pass of the network using the given input
         :param inputs: The input for the network
         :param outputs: The output for the network, defaults to self.outputs
+        :param squeeze_output: call squeeze_list on output
         :return: The network output
 
         WARNING: must only call once per state since each call is assumed by LSTM to be a new time step.
         """
-        # TODO: rename self.inputs -> self.input_placeholders
         feed_dict = self._feed_dict(inputs)
         if outputs is None:
             outputs = self.outputs
@@ -317,7 +317,10 @@ class TensorFlowArchitecture(Architecture):
         else:
             output = self.tp.sess.run(outputs, feed_dict)
 
-        return squeeze_list(output)
+        if squeeze_output:
+            output = squeeze_list(output)
+
+        return output
 
     # def train_on_batch(self, inputs, targets, scaler=1., additional_fetches=None):
     #     """

--- a/architectures/tensorflow_components/architecture.py
+++ b/architectures/tensorflow_components/architecture.py
@@ -15,7 +15,6 @@
 #
 import time
 
-import six
 import numpy as np
 import tensorflow as tf
 
@@ -269,7 +268,7 @@ class TensorFlowArchitecture(Architecture):
     def _feed_dict(self, inputs):
         feed_dict = {}
         for input_name, input_value in inputs.items():
-            if isinstance(input_name, six.string_types):
+            if isinstance(input_name, str):
                 if input_name not in self.inputs:
                     raise ValueError((
                         'input name {input_name} was provided to create a feed '

--- a/architectures/tensorflow_components/heads.py
+++ b/architectures/tensorflow_components/heads.py
@@ -250,7 +250,7 @@ class MeasurementsPredictionHead(Head):
                                             name='output')
             action_stream = tf.reshape(action_stream,
                                        (tf.shape(action_stream)[0], self.num_actions, self.multi_step_measurements_size))
-            action_stream = action_stream - tf.reduce_mean(action_stream, reduction_indices=1, keep_dims=True)
+            action_stream = action_stream - tf.reduce_mean(action_stream, reduction_indices=1, keepdims=True)
 
         # merge to future measurements predictions
         self.output = tf.add(expectation_stream, action_stream, name='output')
@@ -302,7 +302,7 @@ class DNDQHead(Head):
         square_diff = tf.square(dnd_embeddings - tf.expand_dims(input_layer, 1))
         distances = tf.reduce_sum(square_diff, axis=2) + [self.l2_norm_added_delta]
         weights = 1.0 / distances
-        normalised_weights = weights / tf.reduce_sum(weights, axis=1, keep_dims=True)
+        normalised_weights = weights / tf.reduce_sum(weights, axis=1, keepdims=True)
         return tf.reduce_sum(dnd_values * normalised_weights, axis=1)
 
 

--- a/architectures/tensorflow_components/heads.py
+++ b/architectures/tensorflow_components/heads.py
@@ -23,7 +23,7 @@ from utils import force_list
 def normalized_columns_initializer(std=1.0):
     def _initializer(shape, dtype=None, partition_info=None):
         out = np.random.randn(*shape).astype(np.float32)
-        out *= std / np.sqrt(np.square(out).sum(axis=0, keep_dims=True))
+        out *= std / np.sqrt(np.square(out).sum(axis=0, keepdims=True))
         return tf.constant(out)
     return _initializer
 

--- a/architectures/tensorflow_components/heads.py
+++ b/architectures/tensorflow_components/heads.py
@@ -23,7 +23,7 @@ from utils import force_list
 def normalized_columns_initializer(std=1.0):
     def _initializer(shape, dtype=None, partition_info=None):
         out = np.random.randn(*shape).astype(np.float32)
-        out *= std / np.sqrt(np.square(out).sum(axis=0, keepdims=True))
+        out *= std / np.sqrt(np.square(out).sum(axis=0, keep_dims=True))
         return tf.constant(out)
     return _initializer
 
@@ -250,7 +250,7 @@ class MeasurementsPredictionHead(Head):
                                             name='output')
             action_stream = tf.reshape(action_stream,
                                        (tf.shape(action_stream)[0], self.num_actions, self.multi_step_measurements_size))
-            action_stream = action_stream - tf.reduce_mean(action_stream, reduction_indices=1, keepdims=True)
+            action_stream = action_stream - tf.reduce_mean(action_stream, reduction_indices=1, keep_dims=True)
 
         # merge to future measurements predictions
         self.output = tf.add(expectation_stream, action_stream, name='output')
@@ -302,7 +302,7 @@ class DNDQHead(Head):
         square_diff = tf.square(dnd_embeddings - tf.expand_dims(input_layer, 1))
         distances = tf.reduce_sum(square_diff, axis=2) + [self.l2_norm_added_delta]
         weights = 1.0 / distances
-        normalised_weights = weights / tf.reduce_sum(weights, axis=1, keepdims=True)
+        normalised_weights = weights / tf.reduce_sum(weights, axis=1, keep_dims=True)
         return tf.reduce_sum(dnd_values * normalised_weights, axis=1)
 
 

--- a/coach.py
+++ b/coach.py
@@ -326,7 +326,6 @@ if __name__ == "__main__":
                             "--job_name=worker",
                             "--load_json={}".format(json_run_dict_path)]
 
-            print(' '.join(workers_args))
             p = Popen(workers_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1)
 
             if i != run_dict['num_threads']:

--- a/coach.py
+++ b/coach.py
@@ -327,13 +327,15 @@ if __name__ == "__main__":
         set_cpu()
 
         # create a parameter server
-        parameter_server = Popen([
+        cmd = [
             "python3",
            "./parallel_actor.py",
            "--ps_hosts={}".format(ps_hosts),
            "--worker_hosts={}".format(worker_hosts),
            "--job_name=ps",
-        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1)
+        ]
+        print(' '.join(cmd))
+        parameter_server = Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1)
 
         screen.log_title("*** Distributed Training ***")
         time.sleep(1)
@@ -358,6 +360,7 @@ if __name__ == "__main__":
                             "--job_name=worker",
                             "--load_json={}".format(json_run_dict_path)]
 
+            print(' '.join(workers_args))
             p = Popen(workers_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1)
 
             if i != run_dict['num_threads']:

--- a/coach.py
+++ b/coach.py
@@ -300,7 +300,6 @@ if __name__ == "__main__":
            "--worker_hosts={}".format(worker_hosts),
            "--job_name=ps",
         ]
-        print(' '.join(cmd))
         parameter_server = Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1)
 
         screen.log_title("*** Distributed Training ***")

--- a/configurations.py
+++ b/configurations.py
@@ -69,7 +69,7 @@ class Parameters(object):
                 parameters[k] = dict(v.items())
             else:
                 parameters[k] = v
-                
+
         return json.dumps(parameters, indent=4, default=repr)
 
 
@@ -77,7 +77,7 @@ class AgentParameters(Parameters):
     agent = ''
 
     # Architecture parameters
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.Q]
     middleware_type = MiddlewareTypes.FC
     loss_weights = [1.0]
@@ -327,7 +327,7 @@ class Human(AgentParameters):
 
 class NStepQ(AgentParameters):
     type = 'NStepQAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.Q]
     loss_weights = [1.0]
     optimizer_type = 'Adam'
@@ -343,7 +343,7 @@ class NStepQ(AgentParameters):
 
 class DQN(AgentParameters):
     type = 'DQNAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.Q]
     loss_weights = [1.0]
     optimizer_type = 'Adam'
@@ -385,7 +385,7 @@ class QuantileRegressionDQN(DQN):
 class NEC(AgentParameters):
     type = 'NECAgent'
     optimizer_type = 'RMSProp'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.DNDQ]
     loss_weights = [1.0]
     dnd_size = 500000
@@ -399,7 +399,7 @@ class NEC(AgentParameters):
 
 class ActorCritic(AgentParameters):
     type = 'ActorCriticAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.V, OutputTypes.Pi]
     loss_weights = [0.5, 1.0]
     stop_gradients_from_head = [False, False]
@@ -417,7 +417,7 @@ class ActorCritic(AgentParameters):
 
 class PolicyGradient(AgentParameters):
     type = 'PolicyGradientsAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.Pi]
     loss_weights = [1.0]
     num_episodes_in_experience_replay = 2
@@ -430,7 +430,7 @@ class PolicyGradient(AgentParameters):
 
 class DDPG(AgentParameters):
     type = 'DDPGAgent'
-    input_types = [InputTypes.Observation, InputTypes.Action]
+    input_types = {'observation': InputTypes.Observation, 'action': InputTypes.Action}
     output_types = [OutputTypes.V]  # V is used because we only want a single Q value
     loss_weights = [1.0]
     hidden_layers_activation_function = 'relu'
@@ -443,7 +443,7 @@ class DDPG(AgentParameters):
 
 class DDDPG(AgentParameters):
     type = 'DDPGAgent'
-    input_types = [InputTypes.Observation, InputTypes.Action]
+    input_types = {'observation': InputTypes.Observation, 'action': InputTypes.Action}
     output_types = [OutputTypes.V]  # V is used because we only want a single Q value
     loss_weights = [1.0]
     hidden_layers_activation_function = 'relu'
@@ -456,7 +456,7 @@ class DDDPG(AgentParameters):
 
 class NAF(AgentParameters):
     type = 'NAFAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.NAF]
     loss_weights = [1.0]
     hidden_layers_activation_function = 'tanh'
@@ -469,7 +469,7 @@ class NAF(AgentParameters):
 
 class PPO(AgentParameters):
     type = 'PPOAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.V]
     loss_weights = [1.0]
     hidden_layers_activation_function = 'tanh'
@@ -489,7 +489,7 @@ class PPO(AgentParameters):
 
 class ClippedPPO(AgentParameters):
     type = 'ClippedPPOAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.V, OutputTypes.PPO]
     loss_weights = [0.5, 1.0]
     stop_gradients_from_head = [False, False]
@@ -515,7 +515,11 @@ class ClippedPPO(AgentParameters):
 
 class DFP(AgentParameters):
     type = 'DFPAgent'
-    input_types = [InputTypes.Observation, InputTypes.Measurements, InputTypes.GoalVector]
+    input_types = {
+        'observation': InputTypes.Observation,
+        'measurements': InputTypes.Measurements,
+        'goal': InputTypes.GoalVector
+    }
     output_types = [OutputTypes.MeasurementsPrediction]
     loss_weights = [1.0]
     use_measurements = True
@@ -527,7 +531,7 @@ class DFP(AgentParameters):
 
 class MMC(AgentParameters):
     type = 'MixedMonteCarloAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.Q]
     loss_weights = [1.0]
     num_steps_between_copying_online_weights_to_target = 1000
@@ -537,7 +541,7 @@ class MMC(AgentParameters):
 
 class PAL(AgentParameters):
     type = 'PALAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.Q]
     loss_weights = [1.0]
     pal_alpha = 0.9
@@ -548,7 +552,7 @@ class PAL(AgentParameters):
 
 class BC(AgentParameters):
     type = 'BCAgent'
-    input_types = [InputTypes.Observation]
+    input_types = {'observation': InputTypes.Observation}
     output_types = [OutputTypes.Q]
     loss_weights = [1.0]
     collect_new_data = False

--- a/environments/carla_environment_wrapper.py
+++ b/environments/carla_environment_wrapper.py
@@ -161,7 +161,6 @@ class CarlaEnvironmentWrapper(EnvironmentWrapper):
         measurements = []
         while type(measurements) == list:
             measurements, sensor_data = self.game.read_data()
-        self.observation = sensor_data['CameraRGB'].data
 
         self.location = (measurements.player_measurements.transform.location.x,
                          measurements.player_measurements.transform.location.y,
@@ -181,7 +180,10 @@ class CarlaEnvironmentWrapper(EnvironmentWrapper):
                       - np.abs(self.control.steer) * 10
 
         # update measurements
-        self.measurements = [measurements.player_measurements.forward_speed]
+        self.observation = {
+            'observation': sensor_data['CameraRGB'].data,
+            'measurements': [measurements.player_measurements.forward_speed],
+        }
         self.autopilot = measurements.player_measurements.autopilot_control
 
         # action_p = ['%.2f' % member for member in [self.control.throttle, self.control.steer]]

--- a/environments/doom_environment_wrapper.py
+++ b/environments/doom_environment_wrapper.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Intel Corporation 
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -135,8 +135,10 @@ class DoomEnvironmentWrapper(EnvironmentWrapper):
         # extract all data from the current state
         state = self.game.get_state()
         if state is not None and state.screen_buffer is not None:
-            self.observation = state.screen_buffer
-            self.measurements = state.game_variables
+            self.observation = {
+                'observation': state.screen_buffer,
+                'measurements': state.game_variables,
+            }
         self.reward = self.game.get_last_reward()
         self.done = self.game.is_episode_finished()
 
@@ -157,5 +159,3 @@ class DoomEnvironmentWrapper(EnvironmentWrapper):
 
     def _restart_environment_episode(self, force_environment_reset=False):
         self.game.new_episode()
-
-

--- a/environments/environment_wrapper.py
+++ b/environments/environment_wrapper.py
@@ -261,5 +261,4 @@ class EnvironmentWrapper(object):
         This can be different from the state. For example, mujoco's state is a measurements vector.
         :return: numpy array containing the image that will be rendered to the screen
         """
-        # TODO: probably needs revisiting
-        return self.state
+        return self.state['observation']

--- a/environments/gym_environment_wrapper.py
+++ b/environments/gym_environment_wrapper.py
@@ -70,6 +70,18 @@ class GymEnvironmentWrapper(EnvironmentWrapper):
                 scale = 2
             self.renderer.create_screen(image.shape[1]*scale, image.shape[0]*scale)
 
+        if isinstance(self.env.observation_space, gym.spaces.Dict):
+            if 'observation' not in self.env.observation_space:
+                raise ValueError((
+                    'The gym environment provided {env_id} does not contain '
+                    '"observation" in its observation space. For now this is '
+                    'required. The environment does include the following '
+                    'keys in its observation space: {keys}'
+                ).format(
+                    env_id=self.env_id,
+                    keys=self.env.observation_space.keys(),
+                ))
+
         # TODO: collect and store this as observation space instead
         self.is_state_type_image = len(self.state['observation'].shape) > 1
         if self.is_state_type_image:

--- a/logger.py
+++ b/logger.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017 Intel Corporation 
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -250,13 +250,13 @@ class Logger(BaseLogger):
         if 'Training Reward' in self.data.keys() and 'Evaluation Reward' in self.data.keys():
             screen.log_title("Max training reward: {}, max evaluation reward: {}".format(self.data['Training Reward'].max(), self.data['Evaluation Reward'].max()))
         screen.separator()
-        if screen.ask_yes_no("Do you want to discard the experiment results (Warning: this cannot be undone)?", False):
-            self.remove_experiment_dir()
-        elif screen.ask_yes_no("Do you want to specify a different experiment name to save to?", False):
-            new_name = self.get_experiment_name()
-            new_path = self.get_experiment_path(new_name, create_path=False)
-            shutil.move(self.experiments_path, new_path)
-            screen.log_title("Results moved to: {}".format(new_path))
+        # if screen.ask_yes_no("Do you want to discard the experiment results (Warning: this cannot be undone)?", False):
+        #     self.remove_experiment_dir()
+        # elif screen.ask_yes_no("Do you want to specify a different experiment name to save to?", False):
+        #     new_name = self.get_experiment_name()
+        #     new_path = self.get_experiment_path(new_name, create_path=False)
+        #     shutil.move(self.experiments_path, new_path)
+        #     screen.log_title("Results moved to: {}".format(new_path))
 
     def get_experiment_name(self, initial_experiment_name=''):
         match = None

--- a/logger.py
+++ b/logger.py
@@ -250,13 +250,13 @@ class Logger(BaseLogger):
         if 'Training Reward' in self.data.keys() and 'Evaluation Reward' in self.data.keys():
             screen.log_title("Max training reward: {}, max evaluation reward: {}".format(self.data['Training Reward'].max(), self.data['Evaluation Reward'].max()))
         screen.separator()
-        # if screen.ask_yes_no("Do you want to discard the experiment results (Warning: this cannot be undone)?", False):
-        #     self.remove_experiment_dir()
-        # elif screen.ask_yes_no("Do you want to specify a different experiment name to save to?", False):
-        #     new_name = self.get_experiment_name()
-        #     new_path = self.get_experiment_path(new_name, create_path=False)
-        #     shutil.move(self.experiments_path, new_path)
-        #     screen.log_title("Results moved to: {}".format(new_path))
+        if screen.ask_yes_no("Do you want to discard the experiment results (Warning: this cannot be undone)?", False):
+            self.remove_experiment_dir()
+        elif screen.ask_yes_no("Do you want to specify a different experiment name to save to?", False):
+            new_name = self.get_experiment_name()
+            new_path = self.get_experiment_path(new_name, create_path=False)
+            shutil.move(self.experiments_path, new_path)
+            screen.log_title("Results moved to: {}".format(new_path))
 
     def get_experiment_name(self, initial_experiment_name=''):
         match = None

--- a/run_test.py
+++ b/run_test.py
@@ -109,6 +109,7 @@ if __name__ == '__main__':
                     num_workers=preset.test_num_workers,
                     log_file_name=log_file_name,
                 )
+                print('cmd', cmd)
                 p = subprocess.Popen(cmd, shell=True, executable="/bin/bash", preexec_fn=os.setsid)
 
                 # get the csv with the results

--- a/run_test.py
+++ b/run_test.py
@@ -109,7 +109,6 @@ if __name__ == '__main__':
                     num_workers=preset.test_num_workers,
                     log_file_name=log_file_name,
                 )
-                print('cmd', cmd)
                 p = subprocess.Popen(cmd, shell=True, executable="/bin/bash", preexec_fn=os.setsid)
 
                 # get the csv with the results

--- a/utils.py
+++ b/utils.py
@@ -351,3 +351,14 @@ def stack_observation(curr_stack, observation, stack_size):
         curr_stack = np.delete(curr_stack, 0, -1)
 
     return curr_stack
+
+
+def last_sample(state):
+    """
+    given a batch of states, return the last sample of the batch with length 1
+    batch axis.
+    """
+    return {
+        k: np.expand_dims(v[-1], 0)
+        for k, v in state.items()
+    }

--- a/utils.py
+++ b/utils.py
@@ -132,6 +132,7 @@ def parse_int(value):
 
 def set_gpu(gpu_id):
     os.environ['CUDA_VISIBLE_DEVICES'] = str(gpu_id)
+    os.environ['NVIDIA_VISIBLE_DEVICES'] = str(gpu_id)
 
 
 def set_cpu():


### PR DESCRIPTION
- many places in agents which previously work with observations now work with states
- `input_types` now defined as dictionary: `{'name': InputType}`
- `Agent.inputs` now defined as dictionary: `{'name': tf.placeholder}`
- functions which used to accept an input list whose order needed to match the order of `inputs_types` followed by the correct order of inputs added by a specific order of output heads, now accepts a dictionary: `{'name': np.array}`. these functions include: `train_and_sync_networks`, `predict` and `accumulate_gradients`.

Next steps not in this pull request include:
- output_types as dictionary: `{'name': OutputType}`. this will fix awkward names currently used such as: `output_0_0`
- environment observation space defined using `gym.Spaces`

NOTE: `CartPole_NEC` test is failing in this PR, but it also seems to be failing for me in master.