### PR TITLE
fix for tensorboard visualization slowing execution even when it is off

### DIFF
--- a/architectures/tensorflow_components/architecture.py
+++ b/architectures/tensorflow_components/architecture.py
@@ -90,7 +90,8 @@ class TensorFlowArchitecture(Architecture):
             for idx, var in enumerate(self.trainable_weights):
                 placeholder = tf.placeholder(tf.float32, shape=var.get_shape(), name=str(idx) + '_holder')
                 self.weights_placeholders.append(placeholder)
-                variable_summaries(var)
+                if self.tp.visualization.tensorboard:
+                    variable_summaries(var)
 
             self.update_weights_from_list = [weights.assign(holder) for holder, weights in
                                              zip(self.weights_placeholders, self.trainable_weights)]


### PR DESCRIPTION
Apparently tensorflow still collects summary data even when no summary FileWriter is defined over the summaries. This is slowing down execution by 5-10x even when tensorboard visualization is off. 