### PR TITLE
get coach working on Mac and ubuntu 14.04

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from pandas import *
+from pandas import DataFrame
 import os
 import re
 from pprint import pprint

--- a/requirements_dashboard.txt
+++ b/requirements_dashboard.txt
@@ -1,3 +1,4 @@
+tornado==4.5.1
 bokeh==0.12.7
 futures==3.1.1
 pandas==0.20.2


### PR DESCRIPTION
dont import * from pandas because it causes pandas.eval function to be called on many version of linux and mac,  import DataFrame directly instead