### PR TITLE
Ngraph installation using cmake

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -187,8 +187,12 @@ if [ ${INSTALL_NEON} -eq 1 ]; then
     # NGraph
     git clone https://github.com/NervanaSystems/ngraph.git
     cd ngraph
+    mkdir build
+    cd build
+    cmake ..
+    make -j
     make install -j
-    cd ..
+    cd ../..
 
     # Neon
     sudo -E apt-get install libhdf5-dev libyaml-dev pkg-config clang virtualenv libcurl4-openssl-dev libopencv-dev libsox-dev -y


### PR DESCRIPTION
We need to install Ngraph using cmake in the current release of Ngraph.