### PR TITLE
replace loss averaging with summation

### DIFF
--- a/rl_coach/architectures/tensorflow_components/general_network.py
+++ b/rl_coach/architectures/tensorflow_components/general_network.py
@@ -298,7 +298,7 @@ class GeneralTensorFlowNetwork(TensorFlowArchitecture):
         # Losses
         self.losses = tf.losses.get_losses(self.full_name)
         self.losses += tf.losses.get_regularization_losses(self.full_name)
-        self.total_loss = tf.losses.compute_weighted_loss(self.losses, scope=self.full_name)
+        self.total_loss = tf.reduce_sum(self.losses)
         # tf.summary.scalar('total_loss', self.total_loss)
 
         # Learning rate


### PR DESCRIPTION
fix a bug where losses between different heads got averaged instead of summing. affects A3C, PPO, CPPO and other algorithms which use more than a single head.