### PR TITLE
Now able to use and create custom tensorflow heads, embedders, and middleware.

### DIFF
--- a/rl_coach/architectures/embedder_parameters.py
+++ b/rl_coach/architectures/embedder_parameters.py
@@ -40,7 +40,6 @@ class InputEmbedderParameters(NetworkComponentParameters):
         self.input_clipping = input_clipping
         self.name = name
         self.is_training = is_training
-        self.path = None
 
     def path(self, emb_type):
         return 'rl_coach.architectures.tensorflow_components.embedders:' + MOD_NAMES[emb_type]

--- a/rl_coach/architectures/embedder_parameters.py
+++ b/rl_coach/architectures/embedder_parameters.py
@@ -18,6 +18,7 @@ from typing import List, Union
 
 from rl_coach.base_parameters import EmbedderScheme, NetworkComponentParameters
 
+MOD_NAMES = {'image': 'ImageEmbedder', 'vector': 'VectorEmbedder', 'tensor': 'TensorEmbedder'}
 
 class InputEmbedderParameters(NetworkComponentParameters):
     def __init__(self, activation_function: str='relu', scheme: Union[List, EmbedderScheme]=EmbedderScheme.Medium,
@@ -39,3 +40,7 @@ class InputEmbedderParameters(NetworkComponentParameters):
         self.input_clipping = input_clipping
         self.name = name
         self.is_training = is_training
+        self.path = None
+
+    def path(self, emb_type):
+        return 'rl_coach.architectures.tensorflow_components.embedders:' + MOD_NAMES[emb_type]

--- a/rl_coach/architectures/head_parameters.py
+++ b/rl_coach/architectures/head_parameters.py
@@ -31,6 +31,11 @@ class HeadParameters(NetworkComponentParameters):
         self.loss_weight = loss_weight
         self.parameterized_class_name = parameterized_class_name
 
+    @property
+    def path(self):
+        return 'rl_coach.architectures.tensorflow_components.heads:' + self.parameterized_class_name
+
+
 
 class PPOHeadParameters(HeadParameters):
     def __init__(self, activation_function: str ='tanh', name: str='ppo_head_params',

--- a/rl_coach/architectures/middleware_parameters.py
+++ b/rl_coach/architectures/middleware_parameters.py
@@ -32,6 +32,10 @@ class MiddlewareParameters(NetworkComponentParameters):
         self.is_training = is_training
         self.parameterized_class_name = parameterized_class_name
 
+    @property
+    def path(self):
+        return 'rl_coach.architectures.tensorflow_components.middlewares:' + self.parameterized_class_name
+
 
 class FCMiddlewareParameters(MiddlewareParameters):
     def __init__(self, activation_function='relu',

--- a/rl_coach/architectures/tensorflow_components/general_network.py
+++ b/rl_coach/architectures/tensorflow_components/general_network.py
@@ -174,15 +174,13 @@ class GeneralTensorFlowNetwork(TensorFlowArchitecture):
             raise ValueError("The key for the input embedder ({}) must match one of the following keys: {}"
                              .format(input_name, allowed_inputs.keys()))
 
-        mod_names = {'image': 'ImageEmbedder', 'vector': 'VectorEmbedder', 'tensor': 'TensorEmbedder'}
-
         emb_type = "vector"
         if isinstance(allowed_inputs[input_name], TensorObservationSpace):
             emb_type = "tensor"
         elif isinstance(allowed_inputs[input_name], PlanarMapsObservationSpace):
             emb_type = "image"
 
-        embedder_path = 'rl_coach.architectures.tensorflow_components.embedders:' + mod_names[emb_type]
+        embedder_path = embedder_params.path(emb_type)
         embedder_params_copy = copy.copy(embedder_params)
         embedder_params_copy.activation_function = utils.get_activation_function(embedder_params.activation_function)
         embedder_params_copy.input_rescaling = embedder_params_copy.input_rescaling[emb_type]
@@ -200,7 +198,7 @@ class GeneralTensorFlowNetwork(TensorFlowArchitecture):
         :return: the middleware instance
         """
         mod_name = middleware_params.parameterized_class_name
-        middleware_path = 'rl_coach.architectures.tensorflow_components.middlewares:' + mod_name
+        middleware_path = middleware_params.path
         middleware_params_copy = copy.copy(middleware_params)
         middleware_params_copy.activation_function = utils.get_activation_function(middleware_params.activation_function)
         module = dynamic_import_and_instantiate_module_from_params(middleware_params_copy, path=middleware_path)
@@ -214,7 +212,7 @@ class GeneralTensorFlowNetwork(TensorFlowArchitecture):
         :return: the head
         """
         mod_name = head_params.parameterized_class_name
-        head_path = 'rl_coach.architectures.tensorflow_components.heads:' + mod_name
+        head_path = head_params.path
         head_params_copy = copy.copy(head_params)
         head_params_copy.activation_function = utils.get_activation_function(head_params_copy.activation_function)
         return dynamic_import_and_instantiate_module_from_params(head_params_copy, path=head_path, extra_kwargs={


### PR DESCRIPTION
# Ref #134 

I modified the following classes:

* HeadParameters
* MiddlewareParameters
* InputEmbedderParameters

Adding a `path` property (or function as I mention in challenges).

Then I modified:

* `GeneralTensorFlowNetwork.get_input_embedder`
* `GeneralTensorFlowNetwork.get_middleware`
* `GeneralTensorFlowNetwork.get_output_head`

To use these paths instead of their own local's.

I moved a local dictionary inside `GeneralTensorFlowNetwork.get_input_embedder` called mod_names to `embedder_parameters.MOD_NAMES` so that it's more accessible.

# Challenges

* `InputEmbedderParameters.path` can not be a property like the rest. You can call it with `emb_type` and the path will be created. But that's different than how most path's are made.

# Pytest

I ran pytest locally and do not see any dramatic changes in the number of passing tests.