### PR TITLE
'CompositeAgent' object has no attribute 'handle_episode_ended'

### DIFF
--- a/rl_coach/agents/agent_interface.py
+++ b/rl_coach/agents/agent_interface.py
@@ -162,4 +162,14 @@ class AgentInterface(object):
             (could be name of level manager or composite agent)
         :return: collection of all agent savers
         """
-        raise NotImplementedError
+        raise NotImplementedError("")
+
+    def handle_episode_ended(self) -> None:
+        """
+        Make any changes needed when each episode is ended.
+        This includes incrementing counters, updating full episode dependent values, updating logs, etc.
+        This function is called right after each episode is ended.
+
+        :return: None
+        """
+        raise NotImplementedError("")

--- a/rl_coach/agents/composite_agent.py
+++ b/rl_coach/agents/composite_agent.py
@@ -429,3 +429,14 @@ class CompositeAgent(AgentInterface):
             savers.update(agent.collect_savers(
                 parent_path_suffix="{}.{}".format(parent_path_suffix, self.name)))
         return savers
+
+    def handle_episode_ended(self) -> None:
+        """
+        Make any changes needed when each episode is ended.
+        This includes incrementing counters, updating full episode dependent values, updating logs, etc.
+        This function is called right after each episode is ended.
+
+        :return: None
+        """
+        for agent in self.agents.values():
+            agent.handle_episode_ended()


### PR DESCRIPTION
Got this error on a previous run:

```
  File "/usr/local/lib/python3.6/dist-packages/rl_coach/level_manager.py", line 98, in <listcomp>
    [agent.handle_episode_ended() for agent in self.agents.values()]
  AttributeError: 'CompositeAgent' object has no attribute 'handle_episode_ended'
```

Found out that `handle_episode_ended()` is not in `AgentInterface` even so I fixed that (as it's obviously a required element).

Then I added it to `CompositeAgent`.