### PR TITLE
Removed unnecessary observation

### DIFF
--- a/rl_coach/environments/toy_problems/bit_flip.py
+++ b/rl_coach/environments/toy_problems/bit_flip.py
@@ -45,8 +45,7 @@ class BitFlip(gym.Env):
         self.action_space = spaces.Discrete(bit_length)
         self.observation_space = spaces.Dict({
             'state': spaces.Box(low=0, high=1, shape=(bit_length, )),
-            'desired_goal': spaces.Box(low=0, high=1, shape=(bit_length, )),
-            'achieved_goal': spaces.Box(low=0, high=1, shape=(bit_length, ))
+            'desired_goal': spaces.Box(low=0, high=1, shape=(bit_length, ))
         })
 
         self.reset()
@@ -85,8 +84,7 @@ class BitFlip(gym.Env):
     def _get_obs(self):
         return {
             'state': self._mean_zero(self.state),
-            'desired_goal': self._mean_zero(self.goal),
-            'achieved_goal': self._mean_zero(self.state)
+            'desired_goal': self._mean_zero(self.goal)
         }
 
     def render(self, mode='human', close=False):


### PR DESCRIPTION
unless i am missing something, 'achieved_goal' is the exact same thing as 'state' ... so there is probably no need to duplicate it in the observations. referencing this file shows that originally there was only two variables in the observation space 1) the current state 2) the goal state https://github.com/NervanaSystems/gym-bit-flip/blob/master/gym_bit_flip/bit_flip.py