### PR TITLE
Add dump pickle method for environments

### DIFF
--- a/rl_coach/base_parameters.py
+++ b/rl_coach/base_parameters.py
@@ -431,6 +431,7 @@ class VisualizationParameters(Parameters):
                  dump_signals_to_csv_every_x_episodes=5,
                  dump_gifs=False,
                  dump_mp4=False,
+                 dump_pickle=False,
                  video_dump_methods=None,
                  dump_in_episode_signals=False,
                  dump_parameters_documentation=True,
@@ -453,6 +454,9 @@ class VisualizationParameters(Parameters):
             the filters defined in video_dump_methods.
         :param dump_mp4:
             If set to True, MP4 videos of the environment will be stored into the experiment directory according to
+            the filters defined in video_dump_methods.
+        :param dump_pickle:
+            If set to True, pickles of the environment will be stored into the experiment directory according to
             the filters defined in video_dump_methods.
         :param dump_in_episode_signals:
             If set to True, csv files will be dumped for each episode for inspecting different metrics within the
@@ -496,6 +500,7 @@ class VisualizationParameters(Parameters):
         self.dump_csv = dump_csv
         self.dump_gifs = dump_gifs
         self.dump_mp4 = dump_mp4
+        self.dump_pickle = dump_pickle
         self.dump_signals_to_csv_every_x_episodes = dump_signals_to_csv_every_x_episodes
         self.dump_in_episode_signals = dump_in_episode_signals
         self.dump_parameters_documentation = dump_parameters_documentation

--- a/rl_coach/environments/environment.py
+++ b/rl_coach/environments/environment.py
@@ -320,7 +320,8 @@ class Environment(EnvironmentInterface):
 
         # store observations for video / gif dumping
         if self.should_dump_video_of_the_current_episode(episode_terminated=False) and \
-            (self.visualization_parameters.dump_mp4 or self.visualization_parameters.dump_gifs):
+            (self.visualization_parameters.dump_mp4 or self.visualization_parameters.dump_gifs
+                or self.visualization_parameters.dump_pickle):
             self.last_episode_images.append(self.get_rendered_image())
 
         return self.last_env_response
@@ -442,6 +443,9 @@ class Environment(EnvironmentInterface):
             logger.create_gif(self.last_episode_images[::frame_skipping], name=file_name, fps=fps)
         if self.visualization_parameters.dump_mp4:
             logger.create_mp4(self.last_episode_images[::frame_skipping], name=file_name, fps=fps)
+        if self.visualization_parameters.dump_pickle:
+            logger.create_pickle(self.last_episode_images[::frame_skipping], name=file_name)
+
 
     # The following functions define the interaction with the environment.
     # Any new environment that inherits the Environment class should use these signatures.

--- a/rl_coach/logger.py
+++ b/rl_coach/logger.py
@@ -15,7 +15,9 @@
 #
 import atexit
 import datetime
+import gzip
 import os
+import pickle
 import re
 import shutil
 import signal
@@ -357,6 +359,17 @@ def create_mp4(images, fps=10, name="mp4"):
         p.stdin.write(image.tostring())
     p.stdin.close()
     p.wait()
+
+
+def create_pickle(images, name='pickle'):
+    global experiment_path
+    output_file = '{}_{}.pkl.gz'.format(datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S'), name)
+    output_dir = os.path.join(experiment_path or os.getcwd(), 'pickles')
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    output_path = os.path.join(output_dir, output_file)
+    with gzip.open(output_path, 'wb') as fh:
+        pickle.dump(images, fh)
 
 
 def remove_experiment_dir():


### PR DESCRIPTION
Some environments are not suited to video encoding methods.  This PR allows coach to just pickle the environment render responses so that you can use them for analysis.