### PR TITLE
bug fixes for OPE

### DIFF
--- a/rl_coach/agents/agent.py
+++ b/rl_coach/agents/agent.py
@@ -697,7 +697,7 @@ class Agent(AgentInterface):
 
             # we either go sequentially through the entire replay buffer in the batch RL mode,
             # or sample randomly for the basic RL case.
-            training_schedule = self.call_memory('get_shuffled_data_generator', batch_size) if \
+            training_schedule = self.call_memory('get_shuffled_training_data_generator', batch_size) if \
                 self.ap.is_batch_rl_training else [self.call_memory('sample', batch_size) for _ in
                                       range(self.ap.algorithm.num_consecutive_training_steps)]
 

--- a/rl_coach/agents/ddqn_bcq_agent.py
+++ b/rl_coach/agents/ddqn_bcq_agent.py
@@ -155,7 +155,7 @@ class DDQNBCQAgent(DQNAgent):
             reward_model_loss = 0
             imitation_model_loss = 0
             total_transitions_processed = 0
-            for i, batch in enumerate(self.call_memory('get_shuffled_data_generator', batch_size)):
+            for i, batch in enumerate(self.call_memory('get_shuffled_training_data_generator', batch_size)):
                 batch = Batch(batch)
 
                 # reward model

--- a/rl_coach/agents/value_optimization_agent.py
+++ b/rl_coach/agents/value_optimization_agent.py
@@ -164,7 +164,7 @@ class ValueOptimizationAgent(Agent):
         for epoch in range(epochs):
             loss = 0
             total_transitions_processed = 0
-            for i, batch in enumerate(self.call_memory('get_shuffled_data_generator', batch_size)):
+            for i, batch in enumerate(self.call_memory('get_shuffled_training_data_generator', batch_size)):
                 batch = Batch(batch)
                 loss += self.get_reward_model_loss(batch)
                 total_transitions_processed += batch.size

--- a/rl_coach/graph_managers/batch_rl_graph_manager.py
+++ b/rl_coach/graph_managers/batch_rl_graph_manager.py
@@ -173,11 +173,11 @@ class BatchRLGraphManager(BasicRLGraphManager):
         """
         agent = self.level_managers[0].agents['agent']
 
-        screen.log_title("Training a regression model for estimating MDP rewards")
-        agent.improve_reward_model(epochs=self.reward_model_num_epochs)
-
         # prepare dataset to be consumed in the expected formats for OPE
         agent.memory.prepare_evaluation_dataset()
+
+        screen.log_title("Training a regression model for estimating MDP rewards")
+        agent.improve_reward_model(epochs=self.reward_model_num_epochs)
 
         screen.log_title("Collecting static statistics for OPE")
         agent.ope_manager.gather_static_shared_stats(evaluation_dataset_as_transitions=

--- a/rl_coach/memories/non_episodic/experience_replay.py
+++ b/rl_coach/memories/non_episodic/experience_replay.py
@@ -92,7 +92,7 @@ class ExperienceReplay(Memory):
         self.reader_writer_lock.release_writing()
         return batch
 
-    def get_shuffled_data_generator(self, size: int) -> List[Transition]:
+    def get_shuffled_training_data_generator(self, size: int) -> List[Transition]:
         """
         Get an generator for iterating through the shuffled replay buffer, for processing the data in epochs.
         If the requested size is larger than the number of samples available in the replay buffer then the batch will

--- a/rl_coach/off_policy_evaluators/rl/sequential_doubly_robust.py
+++ b/rl_coach/off_policy_evaluators/rl/sequential_doubly_robust.py
@@ -26,7 +26,9 @@ class SequentialDoublyRobust(object):
         """
         Run the off-policy evaluator to get a score for the goodness of the new policy, based on the dataset,
         which was collected using other policy(ies).
-
+        When the epsiodes are of changing lengths, this estimator might prove problematic due to its nature of recursion
+        of adding rewards up to the end of the episode (horizon). It will probably work best with episodes of fixed
+        length.
         Paper: https://arxiv.org/pdf/1511.03722.pdf
 
         :return: the evaluation score
@@ -37,7 +39,7 @@ class SequentialDoublyRobust(object):
 
         for episode in evaluation_dataset_as_episodes:
             episode_seq_dr = 0
-            for transition in episode.transitions:
+            for transition in reversed(episode.transitions):
                 rho = transition.info['softmax_policy_prob'][transition.action] / \
                       transition.info['all_action_probabilities'][transition.action]
                 episode_seq_dr = transition.info['v_value_q_model_based'] + rho * (transition.reward + discount_factor

--- a/rl_coach/off_policy_evaluators/rl/weighted_importance_sampling.py
+++ b/rl_coach/off_policy_evaluators/rl/weighted_importance_sampling.py
@@ -46,8 +46,12 @@ class WeightedImportanceSampling(object):
             per_episode_w_i.append(w_i)
 
         total_w_i_sum_across_episodes = sum(per_episode_w_i)
+
         wis = 0
-        for i, episode in enumerate(evaluation_dataset_as_episodes):
-            wis += per_episode_w_i[i]/total_w_i_sum_across_episodes * episode.transitions[0].n_step_discounted_rewards
+        if total_w_i_sum_across_episodes != 0:
+            for i, episode in enumerate(evaluation_dataset_as_episodes):
+                if len(episode.transitions) != 0:
+                    wis += per_episode_w_i[i] * episode.transitions[0].n_step_discounted_rewards
+            wis /= total_w_i_sum_across_episodes
 
         return wis


### PR DESCRIPTION
Several bug fixes for Sequential Doubly Robust and Weighted Importance Sampling. Also rename of `get_shuffled_data_generator` -> `get_shuffled_training_data_generator`.

Sequential DR had the order of transitions in each episode backwards. Weighted Importance Sampling had some corner cases to be covered. 