### PR TITLE
Checkpoint restore from file bug-fix 

### DIFF
--- a/rl_coach/graph_managers/graph_manager.py
+++ b/rl_coach/graph_managers/graph_manager.py
@@ -575,6 +575,11 @@ class GraphManager(object):
                         self.task_parameters.checkpoint_restore_path))
                 model_checkpoint_path = checkpoint.model_checkpoint_path
                 checkpoint_restore_dir = self.task_parameters.checkpoint_restore_path
+
+                # Set the last checkpoint ID - only in the case of the path being a dir
+                chkpt_state_reader = CheckpointStateReader(self.task_parameters.checkpoint_restore_path,
+                                                           checkpoint_state_optional=False)
+                self.checkpoint_id = chkpt_state_reader.get_latest().num + 1
             else:
                 # a checkpoint file
                 if self.task_parameters.framework_type == Frameworks.tensorflow:
@@ -589,10 +594,6 @@ class GraphManager(object):
             self.checkpoint_saver.restore(self.sess, model_checkpoint_path)
 
             [manager.restore_checkpoint(checkpoint_restore_dir) for manager in self.level_managers]
-
-            # Set the last checkpoint ID
-            chkpt_state_reader = CheckpointStateReader(self.task_parameters.checkpoint_restore_path, checkpoint_state_optional=False)
-            self.checkpoint_id = chkpt_state_reader.get_latest().num + 1
 
     def _get_checkpoint_state_tf(self, checkpoint_restore_dir):
         import tensorflow as tf


### PR DESCRIPTION
Following PR #191, checkpoint restore from a specific file (instead of a directory) is broken. This PR fixes that. 