### PR TITLE
tests: added assert for cp param and changing test args order

### DIFF
--- a/rl_coach/tests/utils/args_utils.py
+++ b/rl_coach/tests/utils/args_utils.py
@@ -391,6 +391,10 @@ def validate_arg_result(flag, p_valid_params, clres=None, process=None,
 
         csv.columns = [column.replace(" ", "_") for column in csv.columns]
         results = csv.query("In_Heatup == 1")
+        total_values = len(results.Total_steps.values)
+        assert len(results.Total_steps.values) > 0, \
+            Def.Consts.ASSERT_MSG("no data in csv", str(total_values))
+
         last_val_in_heatup = results.Total_steps.values[-1]
         assert int(last_val_in_heatup) >= Def.Consts.num_hs, \
             Def.Consts.ASSERT_MSG.format("bigger than " +

--- a/rl_coach/tests/utils/definitions.py
+++ b/rl_coach/tests/utils/definitions.py
@@ -45,7 +45,6 @@ class Definitions:
          ** 1 parameter    = Flag - no need for string or int
          ** 2 parameters   = add value for the selected flag
         """
-
         cmd_args = [
             ['-ew'],
             ['--play'],
@@ -53,9 +52,6 @@ class Definitions:
             ['-f', fw_ten],
             ['--nocolor'],
             ['-s', css],
-            # ['-crd', crd], # Tested in checkpoint test
-            ['-dg'],
-            ['-dm'],
             ['-cp', cp],
             ['--print_networks_summary'],
             ['-tb'],
@@ -63,6 +59,9 @@ class Definitions:
             ['-onnx'],
             ['-asc'],
             ['--dump_worker_logs'],
+            ['-dg'],
+            ['-dm'],
+            # ['-crd', crd], # Tested in checkpoint test
             # ['-et', et],
             # '-lvl': '{level}',  # TODO: Add test validation on args_utils
             # '-e': '{}',  # TODO: Add test validation on args_utils


### PR DESCRIPTION
- fixed cp parameter test 
  - changing params test order, due to xfail tests which keeps the logs and not remove them. 
  - added assert for query indexes