### PR TITLE
ci: using serial jobs in nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,9 +183,9 @@ jobs:
       - run:
           name: run functional tests
           command: |
-            export FUNCTIONAL_PRESETS="'not Mujoco and not CARLA and not Doom'"
+            export FUNCTIONAL_PRESETS="'not Mujoco and not CARLA and not Doom and not Starcraft'"
             python3 rl_coach/tests/test_eks.py -c coach-test -bn ${CIRCLE_BUILD_NUM} -tn functional-test -tc "export FUNCTIONAL_PRESETS=${FUNCTIONAL_PRESETS} && make functional_tests_without_docker" -i 316971102342.dkr.ecr.us-west-2.amazonaws.com/coach:$(git describe --tags --always --dirty) -cpu 2048 -mem 4096
-          no_output_timeout: 30m
+          no_output_timeout: 45m
       - run:
           name: cleanup
           command: |
@@ -676,7 +676,7 @@ workflows:
   weekly:
     triggers:
       - schedule:
-          cron: "0 4 * * 6"
+          cron: "0 1 * * 6"
           filters:
             branches:
               only:
@@ -712,7 +712,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 1 * * *"
+          cron: "0 1 * * 0-5"
           filters:
             branches:
               only:
@@ -731,9 +731,11 @@ workflows:
       - functional_tests:
           requires:
             - build_base
+            - integration_tests
       - functional_test_doom:
           requires:
             - build_doom_env
+            - functional_tests
       - functional_test_mujoco:
           requires:
             - build_mujoco_env
@@ -741,6 +743,7 @@ workflows:
       - golden_test_gym:
           requires:
             - build_gym_env
+            - functional_test_mujoco
       - golden_test_doom:
           requires:
             - build_doom_env


### PR DESCRIPTION
* changing nightly workflow to the following:
- build all env
- run integration and unit tests
- run functional tests
- run doom_functional_tests
- run mujoco_function_tests
- run gym_functional_tests
- run golden gym
- run golden_doom
- run golden_mujoco

* removed Starcraft from functional_tests
* increase timeout on functional tests
* nightly running from Sunday-Friday
* weekly running on Saturday 