### PR TITLE
Wolpertinger preset failure fix

### DIFF
--- a/rl_coach/filters/action/box_discretization.py
+++ b/rl_coach/filters/action/box_discretization.py
@@ -59,7 +59,7 @@ class BoxDiscretization(PartialDiscreteActionSpaceMap):
 
     def get_unfiltered_action_space(self, output_action_space: BoxActionSpace) -> DiscreteActionSpace:
         if isinstance(self.num_bins_per_dimension, int):
-            self.num_bins_per_dimension = np.ones(output_action_space.shape) * self.num_bins_per_dimension
+            self.num_bins_per_dimension = np.ones(output_action_space.shape).astype(int) * self.num_bins_per_dimension
 
         bins = []
         for i in range(len(output_action_space.low)):

--- a/rl_coach/presets/Mujoco_Wolpertinger.py
+++ b/rl_coach/presets/Mujoco_Wolpertinger.py
@@ -32,7 +32,7 @@ agent_params.network_wrappers['critic'].input_embedders_parameters['action'].sch
 agent_params.output_filter = \
     OutputFilter(
         action_filters=OrderedDict([
-            ('discretization', BoxDiscretization(num_bins_per_dimension=1000000))
+            ('discretization', BoxDiscretization(num_bins_per_dimension=[1000000]))
         ]),
         is_a_reference_filter=False
     )

--- a/rl_coach/presets/Mujoco_Wolpertinger.py
+++ b/rl_coach/presets/Mujoco_Wolpertinger.py
@@ -32,7 +32,7 @@ agent_params.network_wrappers['critic'].input_embedders_parameters['action'].sch
 agent_params.output_filter = \
     OutputFilter(
         action_filters=OrderedDict([
-            ('discretization', BoxDiscretization(num_bins_per_dimension=[1000000]))
+            ('discretization', BoxDiscretization(num_bins_per_dimension=int(1e6)))
         ]),
         is_a_reference_filter=False
     )

--- a/rl_coach/presets/Mujoco_Wolpertinger.py
+++ b/rl_coach/presets/Mujoco_Wolpertinger.py
@@ -32,7 +32,7 @@ agent_params.network_wrappers['critic'].input_embedders_parameters['action'].sch
 agent_params.output_filter = \
     OutputFilter(
         action_filters=OrderedDict([
-            ('discretization', BoxDiscretization(num_bins_per_dimension=int(1000000)))
+            ('discretization', BoxDiscretization(num_bins_per_dimension=1000000))
         ]),
         is_a_reference_filter=False
     )

--- a/rl_coach/presets/Mujoco_Wolpertinger.py
+++ b/rl_coach/presets/Mujoco_Wolpertinger.py
@@ -32,7 +32,7 @@ agent_params.network_wrappers['critic'].input_embedders_parameters['action'].sch
 agent_params.output_filter = \
     OutputFilter(
         action_filters=OrderedDict([
-            ('discretization', BoxDiscretization(num_bins_per_dimension=int(1e6)))
+            ('discretization', BoxDiscretization(num_bins_per_dimension=int(1000000)))
         ]),
         is_a_reference_filter=False
     )


### PR DESCRIPTION
Numpy 1.18 fails to cast scientific notation to int in the Wolpertinger preset causing CI failure.